### PR TITLE
feat: emoji markdown plugin

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -418,6 +418,12 @@ function refreshStyles() {
       display: 'block',
       position: 'absolute',
     },
+    largeEmoji: {
+      objectFit: 'contain',
+      height: 28,
+      width: 28,
+      marginHorizontal: 5,
+    },
   });
 }
 export function setTheme(themeName: string) {

--- a/src/components/common/MarkdownView.tsx
+++ b/src/components/common/MarkdownView.tsx
@@ -214,11 +214,14 @@ export const MarkdownView = (props: any) => {
     newProps.style.block_quote,
   );
   const tokens = stringToTokens(newProps.children, defaultMarkdownIt);
-  const inlineTokens = tokens.filter(t => t.type == 'inline')[0].children;
-  if (inlineTokens.every(t => t.type == 'cemoji' || t.type == 'uemoji')) {
-    inlineTokens.forEach(t => {
+  const inlineToken = tokens.filter(t => t.type == 'inline')[0];
+  if (inlineToken) {
+    const children = inlineToken.children;
+    if (children.every(t => t.type == 'cemoji' || t.type == 'uemoji')) {
+      children.forEach(t => {
         t.meta = Object.assign({large: true}, t.meta);
-    });
+      });
+    }
   }
   newProps.children = tokensToAST(tokens);
   try {

--- a/src/components/common/messaging/Emoji.tsx
+++ b/src/components/common/messaging/Emoji.tsx
@@ -14,7 +14,15 @@ import {
   RE_UNICODE_EMOJI,
 } from '../../../lib/consts';
 
-export const SvgEmoji = ({id, pack}: {id: string; pack: EmojiPacks}) => {
+export const SvgEmoji = ({
+  id,
+  pack,
+  large,
+}: {
+  id: string;
+  pack: EmojiPacks;
+  large: boolean;
+}) => {
   const [fail, setFail] = React.useState(false);
   if (fail) {
     return <Text>{`:${id}:`}</Text>;
@@ -22,25 +30,27 @@ export const SvgEmoji = ({id, pack}: {id: string; pack: EmojiPacks}) => {
   if (Object.hasOwn(RevoltEmojiDictionary, id)) {
     id = RevoltEmojiDictionary[id];
   }
+  const style = large ? styles.largeEmoji : styles.emoji;
   return (
     <SvgUri
-      width={styles.emoji.width}
-      height={styles.emoji.height}
-      style={styles.emoji}
+      width={style.width}
+      height={style.height}
+      style={style}
       uri={unicodeEmojiURL(id, pack)}
       onError={() => setFail(true)}
       fallback={<Text>{`:${id}:`}</Text>}
     />
   );
 };
-export const CustomEmoji = ({id}: {id: string}) => {
+export const CustomEmoji = ({id, large}: {id: string; large: boolean}) => {
   const [fail, setFail] = React.useState(false);
   if (fail) {
     return <Text>{`:${id}:`}</Text>;
   }
+  const style = large ? styles.largeEmoji : styles.emoji;
   return (
     <FastImage
-      style={styles.emoji}
+      style={style}
       source={{
         uri: `${client.configuration?.features.autumn.url}/emojis/${id}`,
       }}
@@ -86,5 +96,5 @@ export function emojiPlugin(md) {
     state.pos += openerLength;
     return true;
   }
-  md.inline.ruler.after('emphasis', 'emoji', tokenize);
+  md.inline.ruler.before('spoiler', 'emoji', tokenize);
 }


### PR DESCRIPTION
Emoji tokens are created using colons (:) are markers. Then, the tokens are rendered as components without interfering with other tokens.
Default emoji rendering could be still slow due to the fetch that the SvgUri component does, but it should not cause connection drops.

I also implemented large emojis that are rendered in absence of text tokens.
## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
